### PR TITLE
Added ${MPI_DIR} and ${YAML_DIR} to CMAKE_PREFIX_PATH.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.1)
 project(NaluWindUtils CXX C Fortran)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
-set(CMAKE_PREFIX_PATH ${Trilinos_DIR} ${CMAKE_PREFIX_PATH})
+set(CMAKE_PREFIX_PATH ${Trilinos_DIR} ${MPI_DIR} ${YAML_DIR} ${CMAKE_PREFIX_PATH})
 
 option(ENABLE_WRFTONALU "Enable WRF to Nalu Fortran conversion utility" off)
 option(ENABLE_SPHINX_DOCS "Enable Sphinx-based user/developer manual" off)


### PR DESCRIPTION
This allows the do-config.sh to specify which MPI and which yaml-cpp to use, which can be quite important...  (I ran into two issues related to this: first, I was linking against a different MPI than was used for Trilinos; second, I had a stale yaml-cpp install which used an old version of boost, which in turn failed with an exception when doing the command-line parsing.  This simple change fixed both for me.)