### PR TITLE
Updated wind-utils to the new STK simple_fields workflow

### DIFF
--- a/src/core/CFDMesh.cpp
+++ b/src/core/CFDMesh.cpp
@@ -37,7 +37,9 @@ CFDMesh::CFDMesh
     bulk_(meta_, comm),
     input_db_(filename),
     stkio_(comm)
-{}
+{
+  meta_.use_simple_fields();
+}
 
 CFDMesh::CFDMesh
 (
@@ -62,9 +64,11 @@ void CFDMesh::init(stk::io::DatabasePurpose db_purpose)
     stkio_.add_all_mesh_fields_as_input_fields();
 
     // Everyone needs coordinates
-    VectorFieldType& coords = meta_.declare_field<VectorFieldType>(
-        stk::topology::NODE_RANK, "coordinates");
-    stk::mesh::put_field_on_mesh(coords, meta_.universal_part(), meta_.spatial_dimension(), nullptr);
+    VectorFieldType& coords = meta_.declare_field<double>(
+      stk::topology::NODE_RANK, "coordinates");
+    stk::mesh::put_field_on_mesh(
+      coords, meta_.universal_part(), meta_.spatial_dimension(), nullptr);
+    stk::io::set_field_output_type(coords, stk::io::FieldOutputType::VECTOR_3D);
 }
 
 size_t CFDMesh::open_database(std::string output_db)
@@ -135,7 +139,7 @@ BoxType CFDMesh::calc_bounding_box(const stk::mesh::Selector selector, bool verb
     }
 
     auto& bkts = bulk_.get_buckets(stk::topology::NODE_RANK, selector);
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
 
     for (auto b: bkts) {

--- a/src/core/CFDMesh.h
+++ b/src/core/CFDMesh.h
@@ -21,7 +21,6 @@
 #include "stk_mesh/base/BulkData.hpp"
 #include "stk_mesh/base/Entity.hpp"
 #include "stk_mesh/base/Field.hpp"
-#include "stk_mesh/base/CoordinateSystems.hpp"
 #include "stk_search/Point.hpp"
 #include "stk_search/Box.hpp"
 #include "stk_io/StkMeshIoBroker.hpp"
@@ -33,7 +32,7 @@
 namespace sierra {
 namespace nalu {
 
-typedef stk::mesh::Field<double, stk::mesh::Cartesian> VectorFieldType;
+typedef stk::mesh::Field<double> VectorFieldType;
 typedef stk::mesh::Field<double> ScalarFieldType;
 typedef stk::search::Point<double> PointType;
 typedef stk::search::Box<double> BoxType;

--- a/src/mesh/HexBlockBase.cpp
+++ b/src/mesh/HexBlockBase.cpp
@@ -20,9 +20,9 @@
 #include "core/ParallelInfo.h"
 #include "struct_grid/StructGridIx.h"
 
-#include "stk_mesh/base/TopologyDimensions.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
+#include "stk_io/IossBridge.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -82,9 +82,11 @@ void HexBlockBase::initialize()
 
     pinfo.info() << "HexBlockBase: Registering parts to meta data" << std::endl;
 
-    VectorFieldType& coords = meta_.declare_field<VectorFieldType>(
-        stk::topology::NODE_RANK, "coordinates");
-    stk::mesh::put_field_on_mesh(coords, meta_.universal_part(), meta_.spatial_dimension(), nullptr);
+    VectorFieldType& coords = meta_.declare_field<double>(
+      stk::topology::NODE_RANK, "coordinates");
+    stk::mesh::put_field_on_mesh(
+      coords, meta_.universal_part(), meta_.spatial_dimension(), nullptr);
+    stk::io::set_field_output_type(coords, stk::io::FieldOutputType::VECTOR_3D);
 
     // Block mesh part
     {
@@ -95,7 +97,8 @@ void HexBlockBase::initialize()
 
         pinfo.info() << "\tMesh block: " << blockName_ << std::endl;
 
-        stk::mesh::put_field_on_mesh(coords, part, meta_.spatial_dimension(), nullptr);
+        stk::mesh::put_field_on_mesh(
+          coords, part, meta_.spatial_dimension(), nullptr);
     }
 
     // West

--- a/src/mesh/HexBlockMesh.cpp
+++ b/src/mesh/HexBlockMesh.cpp
@@ -18,7 +18,6 @@
 #include "core/PerfUtils.h"
 #include "core/ParallelInfo.h"
 
-#include "stk_mesh/base/TopologyDimensions.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
 
@@ -191,7 +190,7 @@ void HexBlockMesh::generate_coordinates(const std::vector<stk::mesh::EntityId>& 
     EntID ny = meshDims_[1] + 1;
     EntID nz = meshDims_[2] + 1;
 
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
 
     pinfo.info() << "\t Generating x spacing: " << xspacing_type_ << std::endl;

--- a/src/mesh/Plot3DMesh.cpp
+++ b/src/mesh/Plot3DMesh.cpp
@@ -17,7 +17,6 @@
 #include "core/PerfUtils.h"
 #include "core/ParallelInfo.h"
 
-#include "stk_mesh/base/TopologyDimensions.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
 
@@ -109,7 +108,7 @@ void Plot3DMesh::generate_coordinates(const std::vector<stk::mesh::EntityId>& no
     const int nz = meshDims_[2] + 1;
     int intval;
 
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
 
     std::ifstream p3d(p3dFile_, std::ios::in | std::ios::binary);

--- a/src/mesh/Slice.cpp
+++ b/src/mesh/Slice.cpp
@@ -19,8 +19,8 @@
 #include "core/ParallelInfo.h"
 #include "core/PerfUtils.h"
 
-#include "stk_mesh/base/TopologyDimensions.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
+#include "stk_io/IossBridge.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -123,10 +123,11 @@ void Slice::initialize()
     auto timeMon = get_stopwatch(timerName);
 
     auto& meta = mesh_.meta();
-    auto& coords = meta.declare_field<VectorFieldType>(
+    auto& coords = meta.declare_field<double>(
         stk::topology::NODE_RANK, "coordinates");
     stk::mesh::put_field_on_mesh(
         coords, meta.universal_part(), NDim, nullptr);
+    stk::io::set_field_output_type(coords, stk::io::FieldOutputType::VECTOR_3D);
 
     pinfo.info()
         << "Slice: Registering parts to meta data: " << std::endl;
@@ -221,7 +222,7 @@ void Slice::run()
     }
     bulk.modification_end();
 
-    auto* coords = mesh_.meta().get_field<VectorFieldType>(
+    auto* coords = mesh_.meta().get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
 
     pinfo.info() << "Generating coordinate field" << std::endl;

--- a/src/preprocessing/ABLFields.cpp
+++ b/src/preprocessing/ABLFields.cpp
@@ -19,6 +19,7 @@
 #include "core/YamlUtils.h"
 #include "core/KokkosWrappers.h"
 #include "core/PerfUtils.h"
+#include "stk_io/IossBridge.hpp"
 
 #include <random>
 
@@ -74,16 +75,18 @@ void ABLFields::initialize()
     const std::string timerName = "ABLfields::initialize";
     auto timeMon = get_stopwatch(timerName);
     if (doVelocity_) {
-        VectorFieldType& velocity = meta_.declare_field<VectorFieldType>(
+        VectorFieldType& velocity = meta_.declare_field<double>(
             stk::topology::NODE_RANK, "velocity");
         for(auto part: fluid_parts_) {
-            stk::mesh::put_field_on_mesh(velocity, *part, nullptr);
+            stk::mesh::put_field_on_mesh(velocity, *part, ndim_, nullptr);
+            stk::io::set_field_output_type(
+                velocity, stk::io::FieldOutputType::VECTOR_3D);
         }
         mesh_.add_output_field("velocity");
     }
 
     if (doTemperature_) {
-        ScalarFieldType& temperature = meta_.declare_field<ScalarFieldType>(
+        ScalarFieldType& temperature = meta_.declare_field<double>(
             stk::topology::NODE_RANK, "temperature");
         for(auto part: fluid_parts_) {
             stk::mesh::put_field_on_mesh(temperature, *part, nullptr);
@@ -182,9 +185,9 @@ void ABLFields::init_velocity_field()
     const stk::mesh::BucketVector& fluid_bkts = bulk_.get_buckets(
         stk::topology::NODE_RANK, fluid_union);
 
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
-    VectorFieldType* velocity = meta_.get_field<VectorFieldType>(
+    VectorFieldType* velocity = meta_.get_field<double>(
         stk::topology::NODE_RANK, "velocity");
 
     Kokkos::parallel_for(
@@ -224,9 +227,9 @@ void ABLFields::perturb_velocity_field()
     const stk::mesh::BucketVector& fluid_bkts = bulk_.get_buckets(
         stk::topology::NODE_RANK, fluid_union);
 
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
-    VectorFieldType* velocity = meta_.get_field<VectorFieldType>(
+    VectorFieldType* velocity = meta_.get_field<double>(
         stk::topology::NODE_RANK, "velocity");
 
     auto bbox = mesh_.calc_bounding_box(fluid_union, false);
@@ -275,9 +278,9 @@ void ABLFields::init_temperature_field()
     const stk::mesh::BucketVector& fluid_bkts = bulk_.get_buckets(
         stk::topology::NODE_RANK, fluid_union);
 
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
-    ScalarFieldType* temperature = meta_.get_field<ScalarFieldType>(
+    ScalarFieldType* temperature = meta_.get_field<double>(
         stk::topology::NODE_RANK, "temperature");
 
     Kokkos::parallel_for(
@@ -325,9 +328,9 @@ void ABLFields::perturb_temperature_field()
     const stk::mesh::BucketVector& fluid_bkts = bulk_.get_buckets(
         stk::topology::NODE_RANK, fluid_union);
 
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
-    ScalarFieldType* temperature = meta_.get_field<ScalarFieldType>(
+    ScalarFieldType* temperature = meta_.get_field<double>(
         stk::topology::NODE_RANK, "temperature");
 
     // Random number generator for adding temperature perturbations

--- a/src/preprocessing/BdyIOPlanes.cpp
+++ b/src/preprocessing/BdyIOPlanes.cpp
@@ -17,6 +17,7 @@
 #include "core/PerfUtils.h"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Bucket.hpp"
+#include "stk_io/IossBridge.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -61,7 +62,7 @@ void BdyIOPlanes::initialize()
     auto& iometa = iomesh_.meta();
 
     // We need coordinates
-    VectorFieldType& coords = iometa.declare_field<VectorFieldType>(
+    VectorFieldType& coords = iometa.declare_field<double>(
         stk::topology::NODE_RANK, "coordinates");
 
     for (auto bdyName: bdyNames_) {
@@ -74,7 +75,10 @@ void BdyIOPlanes::initialize()
             bdyName, stk::topology::ELEM_RANK);
         stk::mesh::set_topology(iopart, stk::topology::SHELL_QUAD_4);
         stk::io::put_io_part_attribute(iopart);
-        stk::mesh::put_field_on_mesh(coords, iopart, iometa.spatial_dimension(), nullptr);
+        stk::mesh::put_field_on_mesh(
+            coords, iopart, iometa.spatial_dimension(), nullptr);
+        stk::io::set_field_output_type(
+            coords, stk::io::FieldOutputType::VECTOR_3D);
     }
 }
 
@@ -160,9 +164,9 @@ void BdyIOPlanes::create_boundary(const std::string bdyName)
     iobulk.modification_end();
 
     // Copy coordinates
-    VectorFieldType* fcoords = fmeta.get_field<VectorFieldType>(
+    VectorFieldType* fcoords = fmeta.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
-    VectorFieldType* iocoords = iometa.get_field<VectorFieldType>(
+    VectorFieldType* iocoords = iometa.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
 
     {

--- a/src/preprocessing/ChannelFields.cpp
+++ b/src/preprocessing/ChannelFields.cpp
@@ -15,6 +15,7 @@
 
 
 #include "ChannelFields.h"
+#include "stk_io/IossBridge.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -72,16 +73,18 @@ void ChannelFields::load(const YAML::Node& channel)
 void ChannelFields::initialize()
 {
     if (doVelocity_) {
-        VectorFieldType& velocity = meta_.declare_field<VectorFieldType>(
+        VectorFieldType& velocity = meta_.declare_field<double>(
             stk::topology::NODE_RANK, "velocity");
         for(auto part: fluid_parts_) {
-            stk::mesh::put_field_on_mesh(velocity, *part, nullptr);
+            stk::mesh::put_field_on_mesh(velocity, *part, ndim_, nullptr);
+            stk::io::set_field_output_type(
+                velocity, stk::io::FieldOutputType::VECTOR_3D);
         }
         mesh_.add_output_field("velocity");
     }
 
     if (doTKE_) {
-        ScalarFieldType& tke = meta_.declare_field<ScalarFieldType>(
+        ScalarFieldType& tke = meta_.declare_field<double>(
             stk::topology::NODE_RANK, "turbulent_ke");
         for(auto part: fluid_parts_) {
             stk::mesh::put_field_on_mesh(tke, *part, nullptr);
@@ -156,9 +159,9 @@ void ChannelFields::init_velocity_field()
     const stk::mesh::BucketVector& fluid_bkts = bulk_.get_buckets(
         stk::topology::NODE_RANK, fluid_union);
 
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
-    VectorFieldType* velocity = meta_.get_field<VectorFieldType>(
+    VectorFieldType* velocity = meta_.get_field<double>(
         stk::topology::NODE_RANK, "velocity");
 
     for(size_t ib=0; ib < fluid_bkts.size(); ib++) {
@@ -187,9 +190,9 @@ void ChannelFields::init_tke_field()
     const stk::mesh::BucketVector& fluid_bkts = bulk_.get_buckets(
         stk::topology::NODE_RANK, fluid_union);
 
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
-    ScalarFieldType* tke = meta_.get_field<ScalarFieldType>(
+    ScalarFieldType* tke = meta_.get_field<double>(
         stk::topology::NODE_RANK, "turbulent_ke");
 
     for(size_t ib=0; ib < fluid_bkts.size(); ib++) {

--- a/src/preprocessing/HITFields.cpp
+++ b/src/preprocessing/HITFields.cpp
@@ -18,9 +18,9 @@
 #include "core/KokkosWrappers.h"
 #include "core/PerfUtils.h"
 
-#include "stk_mesh/base/TopologyDimensions.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
+#include "stk_io/IossBridge.hpp"
 
 #include <fstream>
 
@@ -72,10 +72,12 @@ void HITFields::initialize()
     auto timeMon = get_stopwatch(timerName);
 
     auto& meta = mesh_.meta();
-    VectorFieldType& velocity = meta.declare_field<VectorFieldType>(
+    VectorFieldType& velocity = meta.declare_field<double>(
         stk::topology::NODE_RANK, "velocity");
     for (auto part: fluid_parts_) {
-        stk::mesh::put_field_on_mesh(velocity, *part, nullptr);
+        stk::mesh::put_field_on_mesh(velocity, *part, ndim_, nullptr);
+        stk::io::set_field_output_type(
+            velocity, stk::io::FieldOutputType::VECTOR_3D);
     }
     mesh_.add_output_field("velocity");
 }
@@ -93,7 +95,7 @@ void HITFields::run()
     const int ny = hit_mesh_dims_[1];
     const int nz = hit_mesh_dims_[2];
 
-    VectorFieldType* velocity = meta.get_field<VectorFieldType>(
+    VectorFieldType* velocity = meta.get_field<double>(
         stk::topology::NODE_RANK, "velocity");
 
     std::ifstream hitfile(hit_filename_, std::ios::in | std::ios::binary);

--- a/src/preprocessing/InflowHistory.cpp
+++ b/src/preprocessing/InflowHistory.cpp
@@ -20,9 +20,9 @@
 #include "core/PerfUtils.h"
 #include "core/ParallelInfo.h"
 
-#include "stk_mesh/base/TopologyDimensions.hpp"
 #include "stk_mesh/base/FEMHelpers.hpp"
 #include "stk_mesh/base/Field.hpp"
+#include "stk_io/IossBridge.hpp"
 
 #include <fstream>
 #include <vector>
@@ -68,11 +68,13 @@ void InflowHistory::initialize()
     auto timeMon = get_stopwatch(timerName);
 
     auto& meta = mesh_.meta();
-    VectorFieldType& velocity = meta.declare_field<VectorFieldType>(
+    VectorFieldType& velocity = meta.declare_field<double>(
         stk::topology::NODE_RANK, "velocity");
     for (auto part: partVec_) {
         stk::mesh::put_field_on_mesh(
             velocity, *part, meta.spatial_dimension(), nullptr);
+        stk::io::set_field_output_type(
+            velocity, stk::io::FieldOutputType::VECTOR_3D);
     }
 }
 
@@ -93,7 +95,7 @@ void InflowHistory::run()
         throw std::runtime_error(
             "InflowHistory:: Error opening file: " + inflow_filename_);
 
-    auto* velocity = meta.get_field<VectorFieldType>(
+    auto* velocity = meta.get_field<double>(
         stk::topology::NODE_RANK, "velocity");
 
     pinfo.info() << "Writing time-history file = " << output_db_ << std::endl;

--- a/src/preprocessing/NDTW2D.cpp
+++ b/src/preprocessing/NDTW2D.cpp
@@ -14,6 +14,7 @@
 //
 
 #include "NDTW2D.h"
+#include "stk_io/IossBridge.hpp"
 
 namespace sierra {
 namespace nalu {
@@ -73,9 +74,9 @@ void NDTW2D::load(const YAML::Node& wdist)
 
 void NDTW2D::initialize()
 {
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
-    ScalarFieldType& ndtw = meta_.declare_field<ScalarFieldType>(
+    ScalarFieldType& ndtw = meta_.declare_field<double>(
         stk::topology::NODE_RANK, wall_dist_name_);
 
     for(auto part: fluid_parts_) {
@@ -104,9 +105,9 @@ void NDTW2D::calc_ndtw()
     const stk::mesh::BucketVector& wall_bkts = bulk_.get_buckets(
         stk::topology::NODE_RANK, wall_union);
 
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
-    ScalarFieldType* ndtw = meta_.get_field<ScalarFieldType>(
+    ScalarFieldType* ndtw = meta_.get_field<double>(
         stk::topology::NODE_RANK, wall_dist_name_);
 
     std::cout << "Calculating nearest wall distance... " << std::endl;

--- a/src/preprocessing/NestedRefinement.cpp
+++ b/src/preprocessing/NestedRefinement.cpp
@@ -150,7 +150,7 @@ NestedRefinement::initialize()
     const std::string timerName = "NestedRefinement::initialize";
     auto timeMon = get_stopwatch(timerName);
     auto& meta = mesh_.meta();
-    ScalarFieldType& refiner = meta.declare_field<ScalarFieldType>(
+    ScalarFieldType& refiner = meta.declare_field<double>(
         stk::topology::ELEM_RANK, refineFieldName_);
     fluidParts_.resize(fluidPartNames_.size());
     for (size_t i=0; i < fluidPartNames_.size(); i++) {
@@ -160,7 +160,7 @@ NestedRefinement::initialize()
                                      fluidPartNames_[i]);
         else {
             fluidParts_[i] = part;
-            stk::mesh::put_field_on_mesh(refiner, *part, 1, nullptr);
+            stk::mesh::put_field_on_mesh(refiner, *part, nullptr);
         }
     }
     mesh_.add_output_field(refineFieldName_);
@@ -178,9 +178,9 @@ NestedRefinement::run()
         & stk::mesh::selectUnion(fluidParts_);
     const auto& bkts = bulk.get_buckets(
         stk::topology::ELEM_RANK, sel);
-    auto* coords = meta.get_field<VectorFieldType>(
+    auto* coords = meta.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
-    auto* refiner = meta.get_field<ScalarFieldType>(
+    auto* refiner = meta.get_field<double>(
         stk::topology::ELEM_RANK, refineFieldName_);
 
     if (doPrint)

--- a/src/preprocessing/RotateMesh.cpp
+++ b/src/preprocessing/RotateMesh.cpp
@@ -27,7 +27,6 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Entity.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/Comm.hpp>
 
 #include <vector>
@@ -87,7 +86,7 @@ void RotateMesh::run()
 {
     if (bulk_.parallel_rank() == 0)
         std::cout << "Rotating mesh " << std::endl;
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
 
     stk::mesh::Selector s_part = stk::mesh::selectUnion(meshParts_);

--- a/src/preprocessing/SamplingPlanes.cpp
+++ b/src/preprocessing/SamplingPlanes.cpp
@@ -28,9 +28,7 @@
 #include <stk_mesh/base/BulkData.hpp>
 #include <stk_mesh/base/Entity.hpp>
 #include <stk_mesh/base/Field.hpp>
-#include <stk_mesh/base/CoordinateSystems.hpp>
 #include <stk_mesh/base/Comm.hpp>
-#include <stk_mesh/base/TopologyDimensions.hpp>
 #include <stk_mesh/base/FEMHelpers.hpp>
 
 #include <stk_io/IossBridge.hpp>
@@ -147,9 +145,12 @@ void SamplingPlanes::initialize()
 
             if (iproc == 0) std::cout << "\t " << pName << std::endl;
 
-            VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+            VectorFieldType* coords = meta_.get_field<double>(
                 stk::topology::NODE_RANK, "coordinates");
-            stk::mesh::put_field_on_mesh(*coords, part, meta_.spatial_dimension(), nullptr);
+            stk::mesh::put_field_on_mesh(
+                *coords, part, meta_.spatial_dimension(), nullptr);
+            stk::io::set_field_output_type(
+                *coords, stk::io::FieldOutputType::VECTOR_3D);
         }
     }
 }
@@ -173,7 +174,7 @@ void SamplingPlanes::calc_bounding_box()
     const std::string timerName = "SamplingPlanes::calc_bounding_box";
     auto timeMon = get_stopwatch(timerName);
     auto iproc = bulk_.parallel_rank();
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
 
     stk::mesh::Selector s_part = stk::mesh::selectUnion(fluidParts_);
@@ -280,7 +281,7 @@ void SamplingPlanes::generate_zplane(const double zh)
     }
     bulk_.modification_end();
 
-    VectorFieldType* coords = meta_.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta_.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
 
     for (unsigned k=0; k < numPoints; k++) {

--- a/src/preprocessing/TranslateMesh.cpp
+++ b/src/preprocessing/TranslateMesh.cpp
@@ -82,7 +82,7 @@ void TranslateMesh::run()
     auto timeMon = get_stopwatch(timerName);
 
     const int ndim = meta.spatial_dimension();
-    VectorFieldType* coords = meta.get_field<VectorFieldType>(
+    VectorFieldType* coords = meta.get_field<double>(
         stk::topology::NODE_RANK, "coordinates");
     stk::mesh::Selector s_part = stk::mesh::selectUnion(parts_);
     const auto& bkts = bulk.get_buckets(stk::topology::NODE_RANK, s_part);


### PR DESCRIPTION
This commit removes the extra template parameters (beyond just the datatype) from stk::mesh::Field, analogous to the changes made to the main nalu-wind repository.